### PR TITLE
Add an in memory cache HttpMessageHandler

### DIFF
--- a/Cimpress.Extensions.Http.sln
+++ b/Cimpress.Extensions.Http.sln
@@ -7,10 +7,17 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Cimpress.Extensions.Http", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{C53D5145-7C56-41A6-A395-A710C7C6B65C}"
 	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		build.ps1 = build.ps1
 		global.json = global.json
+		nuget.config = nuget.config
 	EndProjectSection
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Cimpress.Extensions.Http.UnitTests", "test\Cimpress.Extensions.Http.UnitTests\Cimpress.Extensions.Http.UnitTests.xproj", "{6EDA0548-12EE-4050-B760-40C591843C78}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Cimpress.Extensions.Http.Caching.InMemory", "src\Cimpress.Extensions.Http.Caching.InMemory\Cimpress.Extensions.Http.Caching.InMemory.xproj", "{4A15550C-F32E-481D-AA1C-E8BE89E01B26}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Cimpress.Extensions.Http.Caching.InMemory.UnitTests", "test\Cimpress.Extensions.Http.Caching.InMemory.UnitTests\Cimpress.Extensions.Http.Caching.InMemory.UnitTests.xproj", "{46D370AA-C52A-4961-8B6A-1C29B86009A8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -26,6 +33,14 @@ Global
 		{6EDA0548-12EE-4050-B760-40C591843C78}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6EDA0548-12EE-4050-B760-40C591843C78}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6EDA0548-12EE-4050-B760-40C591843C78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A15550C-F32E-481D-AA1C-E8BE89E01B26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A15550C-F32E-481D-AA1C-E8BE89E01B26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A15550C-F32E-481D-AA1C-E8BE89E01B26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A15550C-F32E-481D-AA1C-E8BE89E01B26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46D370AA-C52A-4961-8B6A-1C29B86009A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46D370AA-C52A-4961-8B6A-1C29B86009A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46D370AA-C52A-4961-8B6A-1C29B86009A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46D370AA-C52A-4961-8B6A-1C29B86009A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/CacheData.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/CacheData.cs
@@ -1,0 +1,26 @@
+using System.Net.Http;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory
+{
+    /// <summary>
+    /// The data object that is used to put into the cache.
+    /// </summary>
+    internal class CacheData
+    {
+        public CacheData(byte[] data, HttpResponseMessage cachableResponse)
+        {
+            Data = data;
+            CachableResponse = cachableResponse;
+        }
+
+        /// <summary>
+        /// The cachable part of a previously retrieved response (excludes the content and request).
+        /// </summary>
+        public HttpResponseMessage CachableResponse { get; set; }
+
+        /// <summary>
+        /// The content of the response.
+        /// </summary>
+        public byte[] Data { get; set; }
+    }
+}

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/CacheExpirationProvider.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/CacheExpirationProvider.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory
+{
+    /// <summary>
+    /// Provides the parameter needed to specify expiration timeouts based on HttpStatusCode for the <see cref="InMemoryCacheHandler"/>.
+    /// </summary>
+    public static class CacheExpirationProvider
+    {
+        /// <summary>
+        /// Creates a configuration for the <see cref="InMemoryCacheHandler"/> for the success, client error and server error case.
+        /// </summary>
+        /// <param name="success">Cache expiration time for the successful retrieval of data, based on HTTP status code 200-299.</param>
+        /// <param name="clientError">Cache expiration time for the errornous retrieval of data given a client error, based on HTTP status code 400-499.</param>
+        /// <param name="serverError">Cache expiration time for the errornous retrieval of data given a server error, based on HTTP status code 500-599.</param>
+        /// <returns></returns>
+        public static IDictionary<HttpStatusCode, TimeSpan> CreateSimple(TimeSpan success, TimeSpan clientError, TimeSpan serverError)
+        {
+            return new Dictionary<HttpStatusCode, TimeSpan>
+            {
+                {HttpStatusCode.OK, success},
+                {HttpStatusCode.BadRequest, clientError},
+                {HttpStatusCode.InternalServerError, serverError}
+            };
+        }
+    }
+}

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/Cimpress.Extensions.Http.Caching.InMemory.xproj
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/Cimpress.Extensions.Http.Caching.InMemory.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4a15550c-f32e-481d-aa1c-e8be89e01b26</ProjectGuid>
+    <RootNamespace>Cimpress.Extensions.Http.Caching.InMemory</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/HttpResponseMessageExtensions.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/HttpResponseMessageExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory
+{
+    /// <summary>
+    /// Extension methods of the HttpResponseMessage that are related to the caching functionality.
+    /// </summary>
+    internal static class HttpResponseMessageExtensions
+    {
+        /// <summary>
+        /// Takes an HttpResponseMessage and converts that to a <see cref="CacheData"/>.
+        /// </summary>
+        /// <param name="response">The response to put into the cache.</param>
+        /// <returns>A cache entry that can be placed into the cache.</returns>
+        public static async Task<CacheData> ToCacheEntry(this HttpResponseMessage response)
+        {
+            var data = await response.Content.ReadAsByteArrayAsync();
+            var copy = response.CopyCachable();
+            var entry = new CacheData(data, copy);
+            return entry;
+        }
+
+        /// <summary>
+        /// Creates a copy of the HttpResponseMessage excluding non-cacheable data such as the content stream or request based data such as the HttpRequestMessage itself.
+        /// </summary>
+        /// <param name="response">The response to copy.</param>
+        /// <returns>A copy of the response, excluding non-cacheable data.</returns>
+        public static HttpResponseMessage CopyCachable(this HttpResponseMessage response)
+        {
+            var responseCopy = new HttpResponseMessage { ReasonPhrase = response.ReasonPhrase, StatusCode = response.StatusCode, Version = response.Version };
+            foreach (var h in response.Headers)
+            {
+                responseCopy.Headers.Add(h.Key, h.Value);
+            }
+            return responseCopy;
+        }
+    }
+}

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheHandler.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory
+{
+    /// <summary>
+    /// Tries to retrieve the result from an InMemory cache, and if that's not available, gets the value from the underlying handler and caches that result.
+    /// </summary>
+    public class InMemoryCacheHandler : DelegatingHandler
+    {
+        private readonly IDictionary<HttpStatusCode, TimeSpan> cacheExpirationPerHttpResponseCode;
+        private readonly IMemoryCache responseCache;
+
+        /// <summary>
+        /// Create a new InMemoryCacheHandler.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to retrieve the content from on cache misses.</param>
+        /// <param name="cacheExpirationPerHttpResponseCode">A mapping of HttpStatusCode to expiration times. If unspecified takes a default value.</param>
+        public InMemoryCacheHandler(HttpMessageHandler innerHandler, IDictionary<HttpStatusCode, TimeSpan> cacheExpirationPerHttpResponseCode = null)
+            : this(innerHandler, cacheExpirationPerHttpResponseCode, new MemoryCache(new MemoryCacheOptions())) {}
+
+        /// <summary>
+        /// Used for injecting an IMemoryCache for unit testing purposes.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to retrieve the content from on cache misses.</param>
+        /// <param name="cacheExpirationPerHttpResponseCode">A mapping of HttpStatusCode to expiration times. If unspecified takes a default value.</param>
+        /// <param name="cache">The cache to be used.</param>
+        internal InMemoryCacheHandler(HttpMessageHandler innerHandler, IDictionary<HttpStatusCode, TimeSpan> cacheExpirationPerHttpResponseCode, IMemoryCache cache) : base(innerHandler ?? new HttpClientHandler())
+        {
+            this.cacheExpirationPerHttpResponseCode = cacheExpirationPerHttpResponseCode ?? new Dictionary<HttpStatusCode, TimeSpan>();
+            responseCache = cache ?? new MemoryCache(new MemoryCacheOptions());
+        }
+
+        /// <summary>
+        /// Tries to get the value from the cache, and only calls the delegating handler on cache misses.
+        /// </summary>
+        /// <returns>The HttpResponseMessage from cache, or a newly invoked one.</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // gets the data from cache, and returns the data if it's a cache hit
+            CacheData cachedData;
+            if (request.Method == HttpMethod.Get && responseCache.TryGetValue(request.RequestUri, out cachedData))
+            {
+                return PrepareCachedEntry(request, cachedData);
+            }
+
+            // cache misses need to ask the inner handler for an actual response
+            HttpResponseMessage response = await base.SendAsync(request, cancellationToken);
+
+            // puts the retrieved response into the cache and returns the cached entry
+            if (request.Method == HttpMethod.Get)
+            {
+                CacheData entry = await response.ToCacheEntry();
+                TimeSpan absoluteExpirationRelativeToNow = response.StatusCode.GetAbsoluteExpirationRelativeToNow(cacheExpirationPerHttpResponseCode);
+                responseCache.Set(request.RequestUri, entry, absoluteExpirationRelativeToNow);
+                return PrepareCachedEntry(request, entry);
+            }
+
+            // returns the original response
+            return response;
+        }
+
+        /// <summary>
+        /// Prepares the cached entry to be consumed by the caller, notably by setting the content.
+        /// </summary>
+        /// <param name="request">The request that invoked retrieving this response and need to be attached to the response.</param>
+        /// <param name="cachedData">The cache data that hold the data.</param>
+        /// <returns>A valid HttpResponseMessage that can be consumed by the caller of this message handler.</returns>
+        private static HttpResponseMessage PrepareCachedEntry(HttpRequestMessage request, CacheData cachedData)
+        {
+            HttpResponseMessage copy = cachedData.CachableResponse.CopyCachable();
+            copy.Content = new ByteArrayContent(cachedData.Data);
+            copy.RequestMessage = request;
+            return copy;
+        }
+    }
+}

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/Properties/AssemblyInfo.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/Properties/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Cimpress.Extensions.Http.Caching.InMemory")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4a15550c-f32e-481d-aa1c-e8be89e01b26")]
+
+[assembly: InternalsVisibleTo("Cimpress.Extensions.Http.Caching.InMemory.UnitTests")]
+
+//used for mocking:
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/StatusCodeExtensions.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/StatusCodeExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory
+{
+    /// <summary>
+    /// Extension methods to HttpStatusCode that are related to caching functionality of this library.
+    /// </summary>
+    internal static class StatusCodeExtensions
+    {
+        /// <summary>
+        /// Gets an expiration time for the cache entry.
+        /// </summary>
+        /// <param name="statusCode">The status code to inspect the mapping.</param>
+        /// <param name="mapping">The mapping providing configuration of what data to use.</param>
+        /// <returns>A TimeSpan that should be used for the given status code when putting it into the cache.</returns>
+        public static TimeSpan GetAbsoluteExpirationRelativeToNow(this HttpStatusCode statusCode, IDictionary<HttpStatusCode, TimeSpan> mapping)
+        {
+            int code = (int)statusCode;
+            TimeSpan expiration;
+
+            // get the expiration settings for the given status code
+            if (mapping.TryGetValue(statusCode, out expiration))
+            {
+                return expiration;
+            }
+
+            // get the expiration settings for the status code category (200, 300, 400 and 500)
+            if (mapping.TryGetValue((HttpStatusCode)(Math.Floor(code / 100.0) * 100), out expiration))
+            {
+                return expiration;
+            }
+
+            // return the default expiration
+            return TimeSpan.FromDays(1);
+        }
+    }
+}

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/project.json
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/project.json
@@ -1,0 +1,34 @@
+﻿{
+    "version": "0.0.1",
+    "title": ".Net Core Client Extensions for HTTP",
+    "description": ".Net Core Client Extensions for HTTP",
+    "authors": [
+        "Markus Thurner",
+        "Amanda Lobel"
+    ],
+    "packOptions": {
+        "tags": [
+            "HttpClient",
+            "REST",
+            "Networking",
+            "HTTP",
+            "Caching"
+        ],
+        "owners": [
+            "Cimpress"
+        ],
+        "projectUrl": "https://github.com/Cimpress-MCP/dotnet-core-httputils",
+        "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+
+    "dependencies": {
+        "NETStandard.Library": "1.6.0",
+        "Microsoft.Extensions.Caching.Memory":  "1.0.0" 
+    },
+
+    "frameworks": {
+        "netstandard1.6": {
+            "imports": "dnxcore50"
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/CacheExpirationProvider_when_creating_simple_mapping.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/CacheExpirationProvider_when_creating_simple_mapping.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Net;
+using FluentAssertions;
+using Xunit;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
+{
+    public class CacheExpirationProvider_when_creating_simple_mapping
+    {
+        [Fact]
+        public void Puts_the_correct_status_codes_into_the_mapping()
+        {
+            // execute
+            var mappings = CacheExpirationProvider.CreateSimple(TimeSpan.FromTicks(1), TimeSpan.FromTicks(2), TimeSpan.FromTicks(3));
+
+            // validate
+            mappings.Count.Should().Be(3);
+            mappings[HttpStatusCode.OK].Should().Be(TimeSpan.FromTicks(1));
+            mappings[HttpStatusCode.BadRequest].Should().Be(TimeSpan.FromTicks(2));
+            mappings[HttpStatusCode.InternalServerError].Should().Be(TimeSpan.FromTicks(3));
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/Cimpress.Extensions.Http.Caching.InMemory.UnitTests.xproj
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/Cimpress.Extensions.Http.Caching.InMemory.UnitTests.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>46d370aa-c52a-4961-8b6a-1c29b86009a8</ProjectGuid>
+    <RootNamespace>Cimpress.Extensions.Http.Caching.InMemory.UnitTests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheHandler_when_sending_request.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheHandler_when_sending_request.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Xunit;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
+{
+    public class InMemoryCacheHandler_when_sending_request
+    {
+        [Fact]
+        public async Task Caches_the_result()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var client = new HttpClient(new InMemoryCacheHandler(testMessageHandler));
+
+            // execute twice
+            await client.GetAsync("http://unittest");
+            await client.GetAsync("http://unittest");
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Gets_the_data_again_after_entry_is_gone_from_cache()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client = new HttpClient(new InMemoryCacheHandler(testMessageHandler, null, cache));
+
+            // execute twice
+            await client.GetAsync("http://unittest");
+            cache.Remove(new Uri("http://unittest"));
+            await client.GetAsync("http://unittest");
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task Is_case_sensitive()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client = new HttpClient(new InMemoryCacheHandler(testMessageHandler, null, cache));
+
+            // execute for different URLs, only different by casing
+            await client.GetAsync("http://unittest/foo.html");
+            await client.GetAsync("http://unittest/FOO.html");
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+        
+        [Fact]
+        public async Task Caches_per_url()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client = new HttpClient(new InMemoryCacheHandler(testMessageHandler, null, cache));
+
+            // execute for different URLs
+            await client.GetAsync("http://unittest1");
+            await client.GetAsync("http://unittest2");
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+        
+        [Fact]
+        public async Task Only_caches_get_results()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client = new HttpClient(new InMemoryCacheHandler(testMessageHandler, null, cache));
+
+            // execute twice for different methods
+            await client.PostAsync("http://unittest", new StringContent(string.Empty));
+            await client.PostAsync("http://unittest", new StringContent(string.Empty));
+            await client.PutAsync("http://unittest", new StringContent(string.Empty));
+            await client.PutAsync("http://unittest", new StringContent(string.Empty));
+            await client.DeleteAsync("http://unittest");
+            await client.DeleteAsync("http://unittest");
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(6);
+        }
+        
+        [Fact]
+        public async Task Data_from_call_matches_data_from_cache()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client = new HttpClient(new InMemoryCacheHandler(testMessageHandler, null, cache));
+
+            // execute twice for different methods
+            var originalResult = await client.GetAsync("http://unittest");
+            var cachedResult = await client.GetAsync("http://unittest");
+            var originalResultString = await originalResult.Content.ReadAsStringAsync();
+            var cachedResultString = await cachedResult.Content.ReadAsStringAsync();
+
+            // validate
+            originalResultString.ShouldBeEquivalentTo(cachedResultString);
+            originalResultString.ShouldBeEquivalentTo(TestMessageHandler.DefaultContent);
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/Properties/AssemblyInfo.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Cimpress.Extensions.Http.Caching.InMemory.UnitTests")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("46d370aa-c52a-4961-8b6a-1c29b86009a8")]

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/StatusCodeExtensions_when_calculating_cache_expiration.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/StatusCodeExtensions_when_calculating_cache_expiration.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using FluentAssertions;
+using Xunit;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
+{
+    public class StatusCodeExtensions_when_calculating_cache_expiration
+    {
+        [Fact]
+        public void Takes_value_from_Http_code()
+        {
+            // setup
+            var ticks = new Random().Next(0, 100000);
+            var code = HttpStatusCode.NotFound;
+            var mappings = new Dictionary<HttpStatusCode, TimeSpan> { {code, TimeSpan.FromTicks(ticks)} };
+
+            // execute
+            TimeSpan result = code.GetAbsoluteExpirationRelativeToNow(mappings);
+
+            // validate
+            result.Should().Be(mappings[code]);
+        }
+
+        [Fact]
+        public void Takes_value_from_http_code_category()
+        {
+            // setup
+            var r = new Random();
+            var mappings = CacheExpirationProvider.CreateSimple(TimeSpan.FromTicks(r.Next(0, 100000)), TimeSpan.FromTicks(r.Next(0, 100000)), TimeSpan.FromTicks(r.Next(0, 100000)));
+
+            // execute
+            TimeSpan successResult = HttpStatusCode.Created.GetAbsoluteExpirationRelativeToNow(mappings);
+            TimeSpan clientErrorResult = HttpStatusCode.NotFound.GetAbsoluteExpirationRelativeToNow(mappings);
+            TimeSpan serverErrorResult = HttpStatusCode.GatewayTimeout.GetAbsoluteExpirationRelativeToNow(mappings);
+
+            // validate
+            successResult.Should().Be(mappings[HttpStatusCode.OK]);
+            clientErrorResult.Should().Be(mappings[HttpStatusCode.BadRequest]);
+            serverErrorResult.Should().Be(mappings[HttpStatusCode.InternalServerError]);
+        }
+
+        [Fact]
+        public void Takes_default_value()
+        {
+            // setup
+            var mappings = new Dictionary<HttpStatusCode, TimeSpan>();
+
+            // execute
+            TimeSpan result = HttpStatusCode.OK.GetAbsoluteExpirationRelativeToNow(mappings);
+            
+            // validate
+            result.Should().Be(TimeSpan.FromDays(1));
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/TestMessageHandler.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/TestMessageHandler.cs
@@ -1,0 +1,38 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
+{
+    internal class TestMessageHandler : HttpMessageHandler
+    {
+        internal const HttpStatusCode DefaultResponseStatusCode = HttpStatusCode.OK;
+        internal const string DefaultContent = "unit test";
+
+        private readonly HttpStatusCode responseStatusCode;
+        private readonly string content;
+
+        public int NumberOfCalls { get; set; }
+        
+        public TestMessageHandler(HttpStatusCode responseStatusCode = DefaultResponseStatusCode, string content = DefaultContent)
+        {
+            this.responseStatusCode = responseStatusCode;
+            this.content = content;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            NumberOfCalls++;
+
+            // simulate actual result
+            var response = new HttpResponseMessage
+            {
+                Content = new StringContent(content),
+                StatusCode = responseStatusCode
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/project.json
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/project.json
@@ -1,7 +1,7 @@
 ﻿{
     "version": "0.0.1",
-    "title": "Unit tests for Cimpress.Extensions.Http",
-    "description": "Unit tests for Cimpress.Extensions.Http",
+    "title": "Unit tests for Cimpress.Extensions.Http.Caching.InMemory",
+    "description": "Unit tests for Cimpress.Extensions.Http.Caching.InMemory",
     "authors": [
         "Markus Thurner",
         "Amanda Lobel"
@@ -10,7 +10,7 @@
     "testRunner": "xunit",
 
     "dependencies": {
-        "Cimpress.Extensions.Http": { "target": "project" },
+        "Cimpress.Extensions.Http.Caching.InMemory": { "target": "project" },
         "FluentAssertions": "4.9.1",
         "xunit": "2.2.0-beta2-build3300",
         "dotnet-test-xunit": "2.2.0-preview2-build1029",


### PR DESCRIPTION
The InMemoryCacheHandler caches HTTP responses in memory and only retrieves them again from the delegating handler in case the data have expired.
