### PR TITLE
Async sending of log data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vs/
 .vscode/
+.idea/
 obj/
 *.xproj.user
 project.lock.json

--- a/examples/Cimpress.Extensions.Http.Caching.InMemory.Examples/project.json
+++ b/examples/Cimpress.Extensions.Http.Caching.InMemory.Examples/project.json
@@ -9,6 +9,11 @@
 
     "testRunner": "xunit",
 
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
+
     "dependencies": {
         "Cimpress.Extensions.Http.Caching.InMemory": { "target": "project" },
         "FluentAssertions": "4.14.0",

--- a/examples/Cimpress.Extensions.Http.Caching.Redis.Examples/project.json
+++ b/examples/Cimpress.Extensions.Http.Caching.Redis.Examples/project.json
@@ -9,6 +9,11 @@
 
     "testRunner": "xunit",
 
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
+
     "dependencies": {
         "Cimpress.Extensions.Http.Caching.Redis": { "target": "project" },
         "FluentAssertions": "4.14.0",

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
     "sdk": {
         "runtime": "coreclr",
-        "architecture": "x64"
+        "architecture": "x64",
+        "version": "1.0.0-preview2-003121"
     },
     "projects": [ "src", "test", "examples" ]
 }

--- a/src/Cimpress.Extensions.Http.Caching.Abstractions/project.json
+++ b/src/Cimpress.Extensions.Http.Caching.Abstractions/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.0.1",
+    "version": "0.0.1",
     "title": ".Net Core Client Extensions for HTTP",
     "description": ".Net Core Client Extensions for HTTP",
     "authors": [
@@ -20,9 +20,13 @@
         "projectUrl": "https://github.com/Cimpress-MCP/dotnet-core-httputils",
         "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
     },
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
 
     "dependencies": {
-        "NETStandard.Library": "1.6.0"
+      "NETStandard.Library": "1.6.0"
     },
 
     "frameworks": {

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/project.json
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/project.json
@@ -21,6 +21,11 @@
         "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
     },
 
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
+
     "dependencies": {
         "Cimpress.Extensions.Http.Caching.Abstractions": { "target": "project" },
         "NETStandard.Library": "1.6.0",

--- a/src/Cimpress.Extensions.Http.Caching.Redis/project.json
+++ b/src/Cimpress.Extensions.Http.Caching.Redis/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "0.0.1",
+    "version": "0.0.1",
     "title": ".Net Core Client Extensions for HTTP",
     "description": ".Net Core Client Extensions for HTTP",
     "authors": [
@@ -19,6 +19,11 @@
         ],
         "projectUrl": "https://github.com/Cimpress-MCP/dotnet-core-httputils",
         "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
     },
 
     "dependencies": {

--- a/src/Cimpress.Extensions.Http/MessageHandlers/MeasurementDetails.cs
+++ b/src/Cimpress.Extensions.Http/MessageHandlers/MeasurementDetails.cs
@@ -1,0 +1,33 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Cimpress.Extensions.Http.MessageHandlers
+{
+    /// <summary>
+    /// Specifying details from the measurement that get passed into a log function.
+    /// </summary>
+    public class MeasurementDetails
+    {
+        public MeasurementDetails(HttpRequestMessage request, Task<HttpResponseMessage> sendTask, long elapsedMilliseconds)
+        {
+            Request = request;
+            SendTask = sendTask;
+            ElapsedMilliseconds = elapsedMilliseconds;
+        }
+
+        /// <summary>
+        /// The original HTTP request that triggered the measurement.
+        /// </summary>
+        public HttpRequestMessage Request { get; }
+
+        /// <summary>
+        /// The completed (failed, success, canceled) task with the response.
+        /// </summary>
+        public Task<HttpResponseMessage> SendTask { get; }
+
+        /// <summary>
+        /// The elapsed milliseconds to complete the <see cref="SendTask"/>.
+        /// </summary>
+        public long ElapsedMilliseconds { get; }
+    }
+}

--- a/src/Cimpress.Extensions.Http/MessageHandlers/MeasurementHandler.cs
+++ b/src/Cimpress.Extensions.Http/MessageHandlers/MeasurementHandler.cs
@@ -14,11 +14,16 @@ namespace Cimpress.Extensions.Http.MessageHandlers
     {
         public ILogger Logger { get; }
 
-        public MeasurementHandler(ILogger logger) : base(new HttpClientHandler())
+        /// <summary>
+        /// Creates a new measurement handler.
+        /// </summary>
+        /// <param name="logger">The logger where to send the log message to after a request has been completed.</param>
+        /// <param name="innerHandler">The optional inner handler.</param>
+        public MeasurementHandler(ILogger logger, HttpMessageHandler innerHandler = null) : base(innerHandler ?? new HttpClientHandler())
         {
             Logger = logger;
         }
-        
+
         /// <summary>
         /// Measures invocation time of the underlying service call and logs it.
         /// </summary>

--- a/src/Cimpress.Extensions.Http/project.json
+++ b/src/Cimpress.Extensions.Http/project.json
@@ -19,6 +19,10 @@
         "projectUrl": "https://github.com/Cimpress-MCP/dotnet-core-httputils",
         "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
     },
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
 
     "dependencies": {
         "NETStandard.Library": "1.6.0",

--- a/test/Cimpress.Extensions.Http.Caching.Abstractions.UnitTests/project.json
+++ b/test/Cimpress.Extensions.Http.Caching.Abstractions.UnitTests/project.json
@@ -9,6 +9,11 @@
 
     "testRunner": "xunit",
 
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
+
     "dependencies": {
         "Cimpress.Extensions.Http.Caching.Abstractions": { "target": "project" },
         "FluentAssertions": "4.14.0",

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/project.json
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/project.json
@@ -18,6 +18,11 @@
         "System.Diagnostics.TraceSource": "4.0.0"
     },
 
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
+
     "frameworks": {
         "netcoreapp1.5": {
             "imports": [

--- a/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/project.json
+++ b/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/project.json
@@ -9,6 +9,11 @@
 
     "testRunner": "xunit",
 
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
+
     "dependencies": {
         "Cimpress.Extensions.Http.Caching.Redis": { "target": "project" },
         "FluentAssertions": "4.14.0",

--- a/test/Cimpress.Extensions.Http.UnitTests/MessageHandlers/MeasurementHandler_when_logging_results.cs
+++ b/test/Cimpress.Extensions.Http.UnitTests/MessageHandlers/MeasurementHandler_when_logging_results.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Cimpress.Extensions.Http.MessageHandlers;
+using FluentAssertions;
+using Xunit;
+
+namespace Cimpress.Extensions.Http.UnitTests.MessageHandlers
+{
+    public class MeasurementHandler_when_logging_results
+    {
+        private class TestHandler : DelegatingHandler
+        {
+            private readonly TimeSpan executionTime;
+            private readonly HttpStatusCode statusCode;
+            private readonly bool throwException;
+
+            public TestHandler(TimeSpan executionTime, HttpStatusCode statusCode, bool throwException)
+            {
+                this.executionTime = executionTime;
+                this.statusCode = statusCode;
+                this.throwException = throwException;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                await Task.Delay(executionTime, cancellationToken);
+                if (throwException)
+                {
+                    throw new Exception("unit test");
+                }
+                return new HttpResponseMessage(statusCode);
+            }
+        }
+
+        public static IEnumerable<object[]> LogInput
+        {
+            get
+            {
+                yield return new object[] {new Uri("http://unit.test"), HttpStatusCode.OK, false, true, false, false};
+                yield return new object[] {new Uri("http://unit.test/foo/bar"), HttpStatusCode.BadRequest, false, true, false, false};
+                yield return new object[] {new Uri("http://unit.test/xyz.html"), HttpStatusCode.OK, true, true, true, false};
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(LogInput))]
+        public async Task Only_logs_when_completed(Uri uri, HttpStatusCode statusCode, bool throwException, bool isCompleted, bool isFaulted, bool isCanceled)
+        {
+            // setup
+            var resetEvent = new ManualResetEvent(false);
+            Action<MeasurementDetails> logFunc = details =>
+            {
+                // validate
+                details.Request.Method.Method.Should().Be("GET");
+                details.Request.RequestUri.Should().Be(uri);
+                details.SendTask.IsCompleted.Should().Be(isCompleted);
+                details.SendTask.IsFaulted.Should().Be(isFaulted);
+                details.SendTask.IsCanceled.Should().Be(isCanceled);
+                if (!throwException)
+                {
+                    details.SendTask.Result.StatusCode.Should().Be(statusCode);
+                }
+                resetEvent.Set();
+            };
+            var handler = new MeasurementHandler(null, new TestHandler(TimeSpan.FromMilliseconds(100), statusCode, throwException), logFunc);
+            var client = new HttpClient(handler);
+
+            // execute
+            try
+            {
+                await client.GetAsync(uri);
+            }
+            catch (Exception)
+            {
+                if (!throwException) throw;
+            }
+
+            // wait until the validation has completed (but limit to max 1 second to avoid waiting forever)
+            bool awaited = resetEvent.WaitOne(TimeSpan.FromSeconds(1));
+            awaited.Should().BeTrue();
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.UnitTests/project.json
+++ b/test/Cimpress.Extensions.Http.UnitTests/project.json
@@ -9,6 +9,11 @@
 
     "testRunner": "xunit",
 
+    "buildOptions": {
+        "debugType": "portable",
+        "warningsAsErrors": true
+    },
+
     "dependencies": {
         "Cimpress.Extensions.Http": { "target": "project" },
         "FluentAssertions": "4.14.0",


### PR DESCRIPTION
* `MeasurementHandler`: Sends log data not on the main thread, but on a continuation to avoid blocking the main thread for logging purposes.
* Allow to specify an inner `HttpMessageHandler` and a custom logging function for the `MeasurementHandler`.
* Add unit test for the changes.