### PR TITLE
Added test and ability to disable cache per status code

### DIFF
--- a/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheHandler.cs
@@ -62,12 +62,16 @@ namespace Cimpress.Extensions.Http.Caching.InMemory
             // puts the retrieved response into the cache and returns the cached entry
             if (request.Method == HttpMethod.Get)
             {
-                CacheData entry = await response.ToCacheEntry();
                 TimeSpan absoluteExpirationRelativeToNow = response.StatusCode.GetAbsoluteExpirationRelativeToNow(cacheExpirationPerHttpResponseCode);
-                responseCache.Set(request.RequestUri, entry, absoluteExpirationRelativeToNow);
-                HttpResponseMessage cachedResponse = PrepareCachedEntry(request, entry);
-                StatsProvider.ReportCacheMiss(cachedResponse.StatusCode);
-                return cachedResponse;
+
+                if (TimeSpan.Zero != absoluteExpirationRelativeToNow)
+                {
+                    CacheData entry = await response.ToCacheEntry();
+                    responseCache.Set(request.RequestUri, entry, absoluteExpirationRelativeToNow);
+                    HttpResponseMessage cachedResponse = PrepareCachedEntry(request, entry);
+                    StatsProvider.ReportCacheMiss(cachedResponse.StatusCode);
+                    return cachedResponse;
+                }
             }
 
             // returns the original response

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheHandler.cs
@@ -64,12 +64,13 @@ namespace Cimpress.Extensions.Http.Caching.InMemory
             {
                 TimeSpan absoluteExpirationRelativeToNow = response.StatusCode.GetAbsoluteExpirationRelativeToNow(cacheExpirationPerHttpResponseCode);
 
+                StatsProvider.ReportCacheMiss(response.StatusCode);
+
                 if (TimeSpan.Zero != absoluteExpirationRelativeToNow)
                 {
                     CacheData entry = await response.ToCacheEntry();
                     responseCache.Set(request.RequestUri, entry, absoluteExpirationRelativeToNow);
                     HttpResponseMessage cachedResponse = PrepareCachedEntry(request, entry);
-                    StatsProvider.ReportCacheMiss(cachedResponse.StatusCode);
                     return cachedResponse;
                 }
             }

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheHandler_when_sending_request.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheHandler_when_sending_request.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -110,6 +112,25 @@ namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
             // validate
             originalResultString.ShouldBeEquivalentTo(cachedResultString);
             originalResultString.ShouldBeEquivalentTo(TestMessageHandler.DefaultContent);
+        }
+
+        [Fact]
+        public async Task Disable_cache_per_statusCode()
+        {
+            // setup
+            var cacheExpirationPerStatusCode = new Dictionary<HttpStatusCode, TimeSpan>();
+
+            cacheExpirationPerStatusCode.Add((HttpStatusCode)200, TimeSpan.FromSeconds(0));
+
+            var testMessageHandler = new TestMessageHandler();
+            var client = new HttpClient(new InMemoryCacheHandler(testMessageHandler, cacheExpirationPerStatusCode));
+
+            // execute twice
+            await client.GetAsync("http://unittest");
+            await client.GetAsync("http://unittest");
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(2);
         }
     }
 }


### PR DESCRIPTION
This feature would be useful for our application if you would consider merging it in.  We would like to be able to disable caching for certain status codes by passing a 0 TimeSpan into the settings.

Please consider merging.

I was also unsure what to do with this line

`StatsProvider.ReportCacheMiss(cachedResponse.StatusCode);`

Is it a cache miss if you are purposefully not caching the status code?  My implementation is not reporting a cache miss in this scenario, but you're welcome to do what you want with it.