### PR TITLE
Add additional caching strategy

### DIFF
--- a/examples/Cimpress.Extensions.Http.Caching.InMemory.Examples/InMemory_cache_fallback_example.cs
+++ b/examples/Cimpress.Extensions.Http.Caching.InMemory.Examples/InMemory_cache_fallback_example.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Cimpress.Extensions.Http.Caching.Abstractions;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory.Examples
+{
+    public class InMemory_cache_fallback_example
+    {
+        [Theory]
+        [InlineData(10, 4, 1, 2000)] // timeout always occurs, but from the 2nd instance onwards we should get served from the cache
+        [InlineData(5000, 0, 5, 1)] // timeout shouldn't occur; always get it from HTTP
+        public async Task Tests_in_memory_cache_fallback_functionality(int maxTimeoutInMs, int cacheHits, int cacheMisses, int timeoutBetweenExecutions)
+        {
+            const string url = "http://thecatapi.com/api/images/get?format=html";
+            
+            var handler = new InMemoryCacheFallbackHandler(new HttpClientHandler(), TimeSpan.FromMilliseconds(maxTimeoutInMs), TimeSpan.FromDays(100));
+            using (var client = new HttpClient(handler))
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    var sw = Stopwatch.StartNew();
+                    Debug.Write($"Getting data from {url}, iteration #{i + 1}...");
+                    var result = await client.GetAsync(url);
+                    var content = await result.Content.ReadAsStringAsync();
+                    Debug.WriteLine($" completed in {sw.ElapsedMilliseconds}ms. Content was {content}.");
+                    await Task.Delay(timeoutBetweenExecutions);
+                }
+            }
+
+            StatsResult stats = handler.StatsProvider.GetStatistics();
+            stats.Total.CacheHit.Should().Be(cacheHits, "cache hit mismatch");
+            stats.Total.CacheMiss.Should().Be(cacheMisses, "cache miss mismatch");
+        }
+    }
+}

--- a/examples/Cimpress.Extensions.Http.Caching.Redis.Examples/Redis_cache_fallback_example.cs
+++ b/examples/Cimpress.Extensions.Http.Caching.Redis.Examples/Redis_cache_fallback_example.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Cimpress.Extensions.Http.Caching.Abstractions;
+using Cimpress.Extensions.Http.Caching.Redis.Microsoft;
+using FluentAssertions;
+using Xunit;
+
+namespace Cimpress.Extensions.Http.Caching.Redis.Examples
+{
+    public class Redis_cache_fallback_example
+    {
+        [Theory]
+        [InlineData(10, 4, 1, 2000)] // timeout always occurs, but from the 2nd instance onwards we should get served from the cache
+        [InlineData(5000, 0, 5, 1)] // timeout shouldn't occur; always get it from HTTP
+        public async Task Tests_redis_cache_fallback_functionality(int maxTimeoutInMs, int cacheHits, int cacheMisses, int timeoutBetweenExecutions)
+        {
+            const string url = "http://thecatapi.com/api/images/get?format=html";
+
+            RedisCacheOptions options = new RedisCacheOptions
+            {
+                Configuration = "localhost",
+                InstanceName = "example-tests" + Guid.NewGuid() // create a new instance name to ensure a unique key naming to have consistent test results
+            };
+
+            var handler = new RedisCacheFallbackHandler(new HttpClientHandler(), TimeSpan.FromMilliseconds(maxTimeoutInMs), TimeSpan.FromDays(100), options);
+            using (var client = new HttpClient(handler))
+            {
+                for (int i = 0; i < 5; i++)
+                {
+                    var sw = Stopwatch.StartNew();
+                    Debug.Write($"Getting data from {url}, iteration #{i + 1}...");
+                    var result = await client.GetAsync(url);
+                    var content = await result.Content.ReadAsStringAsync();
+                    Debug.WriteLine($" completed in {sw.ElapsedMilliseconds}ms. Content was {content}.");
+                    await Task.Delay(timeoutBetweenExecutions);
+                }
+            }
+
+            StatsResult stats = handler.StatsProvider.GetStatistics();
+            stats.Total.CacheHit.Should().Be(cacheHits, "cache hit mismatch");
+            stats.Total.CacheMiss.Should().Be(cacheMisses, "cache miss mismatch");
+        }
+    }
+}

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheFallbackHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheFallbackHandler.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Cimpress.Extensions.Http.Caching.Abstractions;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory
+{
+    /// <summary>
+    /// Tries to retrieve the result from the HTTP call, and if it times out or results in an unsuccessful status code, tries to get it from cache.
+    /// </summary>
+    public class InMemoryCacheFallbackHandler : DelegatingHandler
+    {
+        public IStatsProvider StatsProvider { get; }
+        private readonly TimeSpan maxTimeout;
+        private readonly TimeSpan cacheDuration;
+        private readonly IMemoryCache responseCache;
+
+        /// <summary>
+        /// Create a new InMemoryCacheHandler.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to retrieve the content from on cache misses.</param>
+        /// <param name="maxTimeout">The maximum timeout to wait for the service to respond.</param>
+        /// <param name="cacheDuration">The maximum time span the item should be remained in the cache if not renewed before then.</param>
+        /// <param name="statsProvider">An <see cref="IStatsProvider"/> that records statistic information about the caching behavior.</param>
+        public InMemoryCacheFallbackHandler(HttpMessageHandler innerHandler, TimeSpan maxTimeout, TimeSpan cacheDuration, IStatsProvider statsProvider = null)
+            : this(innerHandler, maxTimeout, cacheDuration, statsProvider, new MemoryCache(new MemoryCacheOptions())) {}
+
+        /// <summary>
+        /// Used for injecting an IMemoryCache for unit testing purposes.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to retrieve the content from on cache misses.</param>
+        /// <param name="maxTimeout">The maximum timeout to wait for the service to respond.</param>
+        /// <param name="cacheDuration">The maximum time span the item should be remained in the cache if not renewed before then.</param>
+        /// <param name="statsProvider">An <see cref="IStatsProvider"/> that records statistic information about the caching behavior.</param>
+        /// <param name="cache">The cache to be used.</param>
+        internal InMemoryCacheFallbackHandler(HttpMessageHandler innerHandler, TimeSpan maxTimeout, TimeSpan cacheDuration, IStatsProvider statsProvider, IMemoryCache cache) : base(innerHandler ?? new HttpClientHandler())
+        {
+            this.StatsProvider = statsProvider ?? new StatsProvider(nameof(InMemoryCacheHandler));
+            this.maxTimeout = maxTimeout;
+            this.cacheDuration = cacheDuration;
+            responseCache = cache ?? new MemoryCache(new MemoryCacheOptions());
+        }
+
+        /// <summary>
+        /// Tries to get the value from the cache, and only calls the delegating handler on cache misses.
+        /// </summary>
+        /// <returns>The HttpResponseMessage from cache, or a newly invoked one.</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // only handle GET methods
+            if (request.Method != HttpMethod.Get)
+            {
+                return await base.SendAsync(request, cancellationToken);
+            }
+
+            var key = request.RequestUri.ToString();
+
+            // start 3 tasks
+            var httpSendTask = base.SendAsync(request, cancellationToken);
+            var timeoutTask = Task.Delay(maxTimeout, cancellationToken);
+            var cacheTask = responseCache.TryGetAsync(key);
+            
+            // ensure the send task completes (or the timeout task, whatever comes first).
+            var firstCompletedTask = await Task.WhenAny(httpSendTask, timeoutTask);
+
+            // timeout occurred
+            if (firstCompletedTask == timeoutTask)
+            {
+                var data = await ExtractCachedResponse(request, cacheTask);
+                if (data != null)
+                {
+                    // update the cache after the http task eventually completes, without awaiting it
+                    var cacheResultTask = httpSendTask.ContinueWith(t => SaveToCache(t.Result, key), TaskContinuationOptions.OnlyOnRanToCompletion);
+
+                    return data;
+                }
+            }
+
+            // we got it from the HTTP data directly, or it wasn't in the cache and got it after the max timeout value; save that result to the cache and return it
+            var response = await httpSendTask;
+            
+            // try to save it to the cache
+            var entry = await SaveToCache(response, key);
+
+            // when successful, return that value
+            if (entry != null)
+            {
+                StatsProvider.ReportCacheMiss(response.StatusCode);
+                return request.PrepareCachedEntry(entry);
+            }
+
+            // when unsuccessful, try to get it from the cache, which was the last successful invocation
+            var cachedResponse = await ExtractCachedResponse(request, cacheTask);
+            if (cachedResponse != null)
+            {
+                return cachedResponse;
+            }
+
+            StatsProvider.ReportCacheMiss(response.StatusCode);
+
+            return response;
+        }
+
+        private async Task<HttpResponseMessage> ExtractCachedResponse(HttpRequestMessage request, Task<CacheData> cacheTask)
+        { 
+            // get from cache
+            var data = await cacheTask;
+
+            // it's in the cache, return that result
+            if (data != null)
+            {
+                
+                // get the data from the cache
+                var cachedResponse = request.PrepareCachedEntry(data);
+                StatsProvider.ReportCacheHit(cachedResponse.StatusCode);
+                return cachedResponse;
+            }
+
+            return null;
+        }
+
+        private async Task<CacheData> SaveToCache(HttpResponseMessage response, string key)
+        {
+            if (response.IsSuccessStatusCode && TimeSpan.Zero != cacheDuration)
+            {
+                var entry = await response.ToCacheEntry();
+                await responseCache.TrySetAsync(key, entry, cacheDuration);
+                return entry;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheFallbackHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheFallbackHandler.cs
@@ -123,7 +123,7 @@ namespace Cimpress.Extensions.Http.Caching.InMemory
 
         private async Task<CacheData> SaveToCache(HttpResponseMessage response, string key)
         {
-            if (response.IsSuccessStatusCode && TimeSpan.Zero != cacheDuration)
+            if ((int) response.StatusCode < 500 && TimeSpan.Zero != cacheDuration)
             {
                 var entry = await response.ToCacheEntry();
                 await responseCache.TrySetAsync(key, entry, cacheDuration);

--- a/src/Cimpress.Extensions.Http.Caching.Redis/RedisCacheFallbackHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.Redis/RedisCacheFallbackHandler.cs
@@ -126,7 +126,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis
 
         private async Task<CacheData> SaveToCache(HttpResponseMessage response, string key)
         {
-            if (response.IsSuccessStatusCode && TimeSpan.Zero != cacheDuration)
+            if ((int)response.StatusCode < 500 && TimeSpan.Zero != cacheDuration)
             {
                 var entry = await response.ToCacheEntry();
                 await responseCache.TrySetAsync(key, entry, cacheDuration);

--- a/src/Cimpress.Extensions.Http.Caching.Redis/RedisCacheFallbackHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.Redis/RedisCacheFallbackHandler.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Cimpress.Extensions.Http.Caching.Abstractions;
+using Cimpress.Extensions.Http.Caching.Redis.Microsoft;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Cimpress.Extensions.Http.Caching.Redis
+{
+    /// <summary>
+    /// Tries to retrieve the result from a Redis cache, and if that's not available, gets the value from the underlying handler and caches that result.
+    /// </summary>
+    public class RedisCacheFallbackHandler : DelegatingHandler
+    {
+        public IStatsProvider StatsProvider { get; }
+        private readonly TimeSpan maxTimeout;
+        private readonly TimeSpan cacheDuration;
+        private readonly IDistributedCache responseCache;
+
+        /// <summary>
+        /// Used for injecting an IMemoryCache for unit testing purposes.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to retrieve the content from on cache misses.</param>
+        /// <param name="maxTimeout">The maximum timeout to wait for the service to respond.</param>
+        /// <param name="cacheDuration">The maximum time span the item should be remained in the cache if not renewed before then.</param>
+        /// <param name="options">Options to use to connect to Redis.</param>
+        /// /// <param name="statsProvider">An <see cref="IStatsProvider"/> that records statistic information about the caching behavior.</param>
+        public RedisCacheFallbackHandler(HttpMessageHandler innerHandler, TimeSpan maxTimeout, TimeSpan cacheDuration, RedisCacheOptions options,
+            IStatsProvider statsProvider = null) : this(innerHandler, maxTimeout, cacheDuration, new RedisCache(options), statsProvider) {}
+
+        /// <summary>
+        /// Used internally only for unit testing.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler to retrieve the content from on cache misses.</param>
+        /// <param name="maxTimeout">The maximum timeout to wait for the service to respond.</param>
+        /// <param name="cacheDuration">The maximum time span the item should be remained in the cache if not renewed before then.</param>
+        /// <param name="cache">The distributed cache to use.</param>
+        /// /// <param name="statsProvider">An <see cref="IStatsProvider"/> that records statistic information about the caching behavior.</param>
+        internal RedisCacheFallbackHandler(HttpMessageHandler innerHandler, TimeSpan maxTimeout, TimeSpan cacheDuration, IDistributedCache cache,
+            IStatsProvider statsProvider = null) : base(innerHandler ?? new HttpClientHandler())
+        {
+            this.StatsProvider = statsProvider ?? new StatsProvider(nameof(RedisCacheHandler));
+            this.maxTimeout = maxTimeout;
+            this.cacheDuration = cacheDuration;
+            responseCache = cache;
+        }
+
+        /// <summary>
+        /// Tries to get the value from the cache, and only calls the delegating handler on cache misses.
+        /// </summary>
+        /// <returns>The HttpResponseMessage from cache, or a newly invoked one.</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // only handle GET methods
+            if (request.Method != HttpMethod.Get)
+            {
+                return await base.SendAsync(request, cancellationToken);
+            }
+
+            var key = request.RequestUri.ToString();
+
+            // start 3 tasks
+            var httpSendTask = base.SendAsync(request, cancellationToken);
+            var timeoutTask = Task.Delay(maxTimeout, cancellationToken);
+            var cacheTask = responseCache.TryGetAsync(key);
+
+            // ensure the send task completes (or the timeout task, whatever comes first).
+            var firstCompletedTask = await Task.WhenAny(httpSendTask, timeoutTask);
+
+            // timeout occurred
+            if (firstCompletedTask == timeoutTask)
+            {
+                var data = await ExtractCachedResponse(request, cacheTask);
+                if (data != null)
+                {
+                    // update the cache after the http task eventually completes, without awaiting it
+                    var cacheResultTask = httpSendTask.ContinueWith(t => SaveToCache(t.Result, key), TaskContinuationOptions.OnlyOnRanToCompletion);
+
+                    return data;
+                }
+            }
+
+            // we got it from the HTTP data directly, or it wasn't in the cache and got it after the max timeout value; save that result to the cache and return it
+            var response = await httpSendTask;
+
+            // try to save it to the cache
+            var entry = await SaveToCache(response, key);
+
+            // when successful, return that value
+            if (entry != null)
+            {
+                StatsProvider.ReportCacheMiss(response.StatusCode);
+                return request.PrepareCachedEntry(entry);
+            }
+
+            // when unsuccessful, try to get it from the cache, which was the last successful invocation
+            var cachedResponse = await ExtractCachedResponse(request, cacheTask);
+            if (cachedResponse != null)
+            {
+                return cachedResponse;
+            }
+
+            StatsProvider.ReportCacheMiss(response.StatusCode);
+
+            return response;
+        }
+
+        private async Task<HttpResponseMessage> ExtractCachedResponse(HttpRequestMessage request, Task<CacheData> cacheTask)
+        {
+            // get from cache
+            var data = await cacheTask;
+
+            // it's in the cache, return that result
+            if (data != null)
+            {
+
+                // get the data from the cache
+                var cachedResponse = request.PrepareCachedEntry(data);
+                StatsProvider.ReportCacheHit(cachedResponse.StatusCode);
+                return cachedResponse;
+            }
+
+            return null;
+        }
+
+        private async Task<CacheData> SaveToCache(HttpResponseMessage response, string key)
+        {
+            if (response.IsSuccessStatusCode && TimeSpan.Zero != cacheDuration)
+            {
+                var entry = await response.ToCacheEntry();
+                await responseCache.TrySetAsync(key, entry, cacheDuration);
+                return entry;
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheFallbackHandler_when_sending_request.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheFallbackHandler_when_sending_request.cs
@@ -116,7 +116,7 @@ namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
         {
             // setup
             var testMessageHandler1 = new TestMessageHandler(HttpStatusCode.OK, "message-1");
-            var testMessageHandler2 = new TestMessageHandler(HttpStatusCode.BadRequest, "message-2");
+            var testMessageHandler2 = new TestMessageHandler(HttpStatusCode.InternalServerError, "message-2");
             var cache = new MemoryCache(new MemoryCacheOptions());
             var client1 = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler1, TimeSpan.FromDays(1), TimeSpan.FromDays(1), null, cache));
             var client2 = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler2, TimeSpan.FromDays(1), TimeSpan.FromDays(1), null, cache));

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheFallbackHandler_when_sending_request.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheFallbackHandler_when_sending_request.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Xunit;
+
+namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
+{
+    public class InMemoryCacheFallbackHandler_when_sending_request
+    {
+        private string url = "http://unittest/";
+
+        [Fact]
+        public async Task Always_calls_the_http_handler()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), TimeSpan.FromDays(1), null, cache));
+
+            // execute twice
+            await client.GetAsync(url);
+            cache.Get(url).Should().NotBeNull(); // ensure it's cached before the 2nd call
+            await client.GetAsync(url);
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task Always_updates_the_cache_on_success()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
+            var cacheTime = TimeSpan.FromSeconds(123);
+            cache.Setup(c => c.CreateEntry(url));
+            var client = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
+
+            // execute twice, validate cache is called each time
+            await client.GetAsync(url);
+            cache.Verify(c => c.CreateEntry(url), Times.Once);
+            await client.GetAsync(url);
+            cache.Verify(c => c.CreateEntry(url), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task Never_updates_the_cache_on_failure()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler(HttpStatusCode.InternalServerError);
+            var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
+            var cacheTime = TimeSpan.FromSeconds(123);
+            object expectedValue;
+            cache.Setup(c => c.CreateEntry(It.IsAny<string>()));
+            cache.Setup(c => c.TryGetValue(url, out expectedValue)).Returns(false);
+            var client = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
+
+            // execute
+            await client.GetAsync(url);
+            
+            // validate
+            cache.Verify(c => c.CreateEntry(It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Tries_to_access_cache_on_failure_but_returns_error_if_not_in_cache()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler(HttpStatusCode.InternalServerError);
+            var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
+            var cacheTime = TimeSpan.FromSeconds(123);
+            object expectedValue;
+            cache.Setup(c => c.TryGetValue(url, out expectedValue)).Returns(false);
+            var client = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
+
+            // execute
+            var result = await client.GetAsync(url);
+
+            // validate
+            result.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        }
+
+        [Fact]
+        public async Task Gets_it_from_the_http_call_after_being_in_cache()
+        {
+            // setup
+            var testMessageHandler1 = new TestMessageHandler(content: "message-1", delay: TimeSpan.FromMilliseconds(100));
+            var testMessageHandler2 = new TestMessageHandler(content: "message-2");
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client1 = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler1, TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(1), null, cache));
+            var client2 = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler2, TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(1), null, cache));
+
+            // execute twice
+            var result1 = await client1.GetAsync(url);
+            cache.Get(url).Should().NotBeNull();
+            var result2 = await client2.GetAsync(url);
+
+            // validate
+            // - that each message handler got called
+            testMessageHandler1.NumberOfCalls.Should().Be(1);
+            testMessageHandler2.NumberOfCalls.Should().Be(1);
+
+            // - that the 2nd result got served from the http call
+            var data1 = await result1.Content.ReadAsStringAsync();
+            var data2 = await result2.Content.ReadAsStringAsync();
+            data1.Should().BeEquivalentTo("message-1");
+            data2.Should().BeEquivalentTo("message-2");
+        }
+
+        [Fact]
+        public async Task Gets_it_from_the_cache_when_unsuccessful()
+        {
+            // setup
+            var testMessageHandler1 = new TestMessageHandler(HttpStatusCode.OK, "message-1");
+            var testMessageHandler2 = new TestMessageHandler(HttpStatusCode.BadRequest, "message-2");
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            var client1 = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler1, TimeSpan.FromDays(1), TimeSpan.FromDays(1), null, cache));
+            var client2 = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler2, TimeSpan.FromDays(1), TimeSpan.FromDays(1), null, cache));
+
+            // execute twice
+            var result1 = await client1.GetAsync(url);
+            var result2 = await client2.GetAsync(url);
+
+            // validate
+            // - that each message handler got called
+            testMessageHandler1.NumberOfCalls.Should().Be(1);
+            testMessageHandler2.NumberOfCalls.Should().Be(1);
+
+            // - that the 2nd result got served from cache
+            var data1 = await result1.Content.ReadAsStringAsync();
+            var data2 = await result2.Content.ReadAsStringAsync();
+            data1.Should().BeEquivalentTo("message-1");
+            data2.Should().BeEquivalentTo(data1);
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/TestMessageHandler.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/TestMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,28 +16,32 @@ namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
         private readonly HttpStatusCode responseStatusCode;
         private readonly string content;
         private readonly string contentType;
+        private readonly TimeSpan delay;
         private readonly Encoding encoding;
 
         public int NumberOfCalls { get; set; }
         
-        public TestMessageHandler(HttpStatusCode responseStatusCode = DefaultResponseStatusCode, string content = DefaultContent, string contentType = DefaultContentType, Encoding encoding = null)
+        public TestMessageHandler(HttpStatusCode responseStatusCode = DefaultResponseStatusCode, string content = DefaultContent, string contentType = DefaultContentType, Encoding encoding = null, TimeSpan delay = default(TimeSpan))
         {
             this.responseStatusCode = responseStatusCode;
             this.content = content;
             this.contentType = contentType;
+            this.delay = delay;
             this.encoding = encoding ?? Encoding.UTF8;
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             NumberOfCalls++;
 
-            // simulate actual result
-            return Task.FromResult(new HttpResponseMessage()
+            // optional delay
+            if (delay != default(TimeSpan))
             {
-                Content = new StringContent(content, this.encoding, this.contentType),
-                StatusCode = responseStatusCode
-            });
+                await Task.Delay(delay, cancellationToken);
+            }
+
+            // simulate actual result
+            return new HttpResponseMessage {Content = new StringContent(content, this.encoding, this.contentType), StatusCode = responseStatusCode};
         }
 
     }

--- a/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheFallbackHandler_when_sending_requests.cs
+++ b/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheFallbackHandler_when_sending_requests.cs
@@ -121,7 +121,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var serializedCacheEntry = cacheEntryToSerialize.Serialize();
 
             var testMessageHandler1 = new TestMessageHandler(HttpStatusCode.OK, "message-1");
-            var testMessageHandler2 = new TestMessageHandler(HttpStatusCode.BadRequest, "message-2");
+            var testMessageHandler2 = new TestMessageHandler(HttpStatusCode.InternalServerError, "message-2");
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
             cache.SetupSequence(c => c.GetAsync(url)).ReturnsAsync(default(byte[])).ReturnsAsync(serializedCacheEntry);
             var client1 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler1, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));

--- a/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheFallbackHandler_when_sending_requests.cs
+++ b/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheFallbackHandler_when_sending_requests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Cimpress.Extensions.Http.Caching.Abstractions;
+using Microsoft.Extensions.Caching.Distributed;
+using Moq;
+using Xunit;
+
+namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
+{
+    public class RedisCacheFallbackHandler_when_sending_requests
+    {
+        private string url = "http://unittest/";
+
+        [Fact]
+        public async Task Always_calls_the_http_handler()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
+            cache.Setup(c => c.SetAsync(url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>())).Returns(Task.FromResult(true));
+            var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
+
+            // execute twice
+            await client.GetAsync(url);
+            cache.Verify(c => c.SetAsync(url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once); // ensure it's cached before the 2nd call
+            await client.GetAsync(url);
+
+            // validate
+            testMessageHandler.NumberOfCalls.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task Always_updates_the_cache_on_success()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler();
+            var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
+            var cacheTime = TimeSpan.FromSeconds(123);
+            cache.Setup(c => c.SetAsync(url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>())).Returns(Task.FromResult(true));
+            var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, cache.Object));
+
+            // execute twice, validate cache is called each time
+            await client.GetAsync(url);
+            cache.Verify(c => c.SetAsync(url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);
+            await client.GetAsync(url);
+            cache.Verify(c => c.SetAsync(url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task Never_updates_the_cache_on_failure()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler(HttpStatusCode.InternalServerError);
+            var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
+            var cacheTime = TimeSpan.FromSeconds(123);
+            cache.Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>())).Returns(Task.FromResult(true));
+            cache.Setup(c => c.GetAsync(url)).ReturnsAsync(default(byte[]));
+            var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, cache.Object));
+
+            // execute
+            await client.GetAsync(url);
+
+            // validate
+            cache.Verify(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task Tries_to_access_cache_on_failure_but_returns_error_if_not_in_cache()
+        {
+            // setup
+            var testMessageHandler = new TestMessageHandler(HttpStatusCode.InternalServerError);
+            var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
+            var cacheTime = TimeSpan.FromSeconds(123);
+            cache.Setup(c => c.GetAsync(url)).ReturnsAsync(default(byte[]));
+            var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, cache.Object));
+
+            // execute
+            var result = await client.GetAsync(url);
+
+            // validate
+            result.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        }
+
+        [Fact]
+        public async Task Gets_it_from_the_http_call_after_being_in_cache()
+        {
+            // setup
+            var testMessageHandler1 = new TestMessageHandler(content: "message-1", delay: TimeSpan.FromMilliseconds(100));
+            var testMessageHandler2 = new TestMessageHandler(content: "message-2");
+            var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
+            cache.Setup(c => c.SetAsync(url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>())).Returns(Task.FromResult(true));
+            var client1 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler1, TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(1), cache.Object));
+            var client2 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler2, TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(1), cache.Object));
+
+            // execute twice
+            var result1 = await client1.GetAsync(url);
+            cache.Verify(c => c.SetAsync(url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);
+            var result2 = await client2.GetAsync(url);
+
+            // validate
+            // - that each message handler got called
+            testMessageHandler1.NumberOfCalls.Should().Be(1);
+            testMessageHandler2.NumberOfCalls.Should().Be(1);
+
+            // - that the 2nd result got served from cache
+            var data1 = await result1.Content.ReadAsStringAsync();
+            var data2 = await result2.Content.ReadAsStringAsync();
+            data1.Should().BeEquivalentTo("message-1");
+            data2.Should().BeEquivalentTo("message-2");
+        }
+
+        [Fact]
+        public async Task Gets_it_from_the_cache_when_unsuccessful()
+        {
+            // setup
+            var responseToSerialize = await new HttpClient(new TestMessageHandler(HttpStatusCode.OK, "message-1")).GetAsync(url);
+            var cacheEntryToSerialize = await responseToSerialize.ToCacheEntry();
+            var serializedCacheEntry = cacheEntryToSerialize.Serialize();
+
+            var testMessageHandler1 = new TestMessageHandler(HttpStatusCode.OK, "message-1");
+            var testMessageHandler2 = new TestMessageHandler(HttpStatusCode.BadRequest, "message-2");
+            var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
+            cache.SetupSequence(c => c.GetAsync(url)).ReturnsAsync(default(byte[])).ReturnsAsync(serializedCacheEntry);
+            var client1 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler1, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
+            var client2 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler2, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
+
+            // execute twice
+            var result1 = await client1.GetAsync(url);
+            var result2 = await client2.GetAsync(url);
+
+            // validate
+            // - that each message handler got called
+            testMessageHandler1.NumberOfCalls.Should().Be(1);
+            testMessageHandler2.NumberOfCalls.Should().Be(1);
+
+            // - that the 2nd result got served from cache
+            var data1 = await result1.Content.ReadAsStringAsync();
+            var data2 = await result2.Content.ReadAsStringAsync();
+            data1.Should().BeEquivalentTo("message-1");
+            data2.Should().BeEquivalentTo(data1);
+        }
+    }
+}

--- a/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/TestMessageHandler.cs
+++ b/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/TestMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -16,31 +17,34 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
         private readonly HttpStatusCode responseStatusCode;
         private readonly string content;
         private readonly string contentType;
+        private readonly TimeSpan delay;
         private readonly Encoding encoding;
         private readonly EntityTagHeaderValue etag;
 
         public int NumberOfCalls { get; set; }
         
-        public TestMessageHandler(HttpStatusCode responseStatusCode = DefaultResponseStatusCode, string content = DefaultContent, string contentType = DefaultContentType, EntityTagHeaderValue etag = null, Encoding encoding = null)
+        public TestMessageHandler(HttpStatusCode responseStatusCode = DefaultResponseStatusCode, string content = DefaultContent, string contentType = DefaultContentType, EntityTagHeaderValue etag = null, Encoding encoding = null, TimeSpan delay = default(TimeSpan))
         {
             this.responseStatusCode = responseStatusCode;
             this.content = content;
             this.contentType = contentType;
+            this.delay = delay;
             this.encoding = encoding ?? Encoding.UTF8;
             this.etag = etag ?? default(EntityTagHeaderValue);
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             NumberOfCalls++;
 
-            // simulate actual result
-            return Task.FromResult(new HttpResponseMessage
+            // optional delay
+            if (delay != default(TimeSpan))
             {
-                Headers = {ETag = this.etag},
-                Content = new StringContent(content, this.encoding, this.contentType),
-                StatusCode = responseStatusCode
-            });
+                await Task.Delay(delay, cancellationToken);
+            }
+
+            // simulate actual result
+            return new HttpResponseMessage {Headers = {ETag = this.etag}, Content = new StringContent(content, this.encoding, this.contentType), StatusCode = responseStatusCode};
         }
 
     }


### PR DESCRIPTION
The additional caching strategy allows to deal with outages of underlying services. That is, it relies on the underlying service, but after a given timeout or on an unsuccessful status code, tries to get it from cache. If the cached data aren't available, it falls back to awaiting the actual HTTP call.

The InMemory and Redis implementation are handled through code duplication. I want to keep refactoring the library into additional modules outside of this pull request.