### PR TITLE
Use distinguished key for each cache method

### DIFF
--- a/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheFallbackHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.InMemory/InMemoryCacheFallbackHandler.cs
@@ -16,6 +16,7 @@ namespace Cimpress.Extensions.Http.Caching.InMemory
         private readonly TimeSpan maxTimeout;
         private readonly TimeSpan cacheDuration;
         private readonly IMemoryCache responseCache;
+        internal const string CacheFallbackKeyPrefix = "cfb";
 
         /// <summary>
         /// Create a new InMemoryCacheHandler.
@@ -55,7 +56,7 @@ namespace Cimpress.Extensions.Http.Caching.InMemory
                 return await base.SendAsync(request, cancellationToken);
             }
 
-            var key = request.Method + request.RequestUri.ToString();
+            var key = CacheFallbackKeyPrefix + request.Method + request.RequestUri.ToString();
 
             // start 3 tasks
             var httpSendTask = base.SendAsync(request, cancellationToken);

--- a/src/Cimpress.Extensions.Http.Caching.Redis/RedisCacheFallbackHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.Redis/RedisCacheFallbackHandler.cs
@@ -17,6 +17,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis
         private readonly TimeSpan maxTimeout;
         private readonly TimeSpan cacheDuration;
         private readonly IDistributedCache responseCache;
+        internal const string CacheFallbackKeyPrefix = "cfb";
 
         /// <summary>
         /// Used for injecting an IMemoryCache for unit testing purposes.
@@ -58,7 +59,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis
                 return await base.SendAsync(request, cancellationToken);
             }
 
-            var key = request.Method + request.RequestUri.ToString();
+            var key = CacheFallbackKeyPrefix + request.Method + request.RequestUri;
 
             // start 3 tasks
             var httpSendTask = base.SendAsync(request, cancellationToken);

--- a/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheFallbackHandler_when_sending_request.cs
+++ b/test/Cimpress.Extensions.Http.Caching.InMemory.UnitTests/InMemoryCacheFallbackHandler_when_sending_request.cs
@@ -23,7 +23,7 @@ namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
 
             // execute twice
             await client.GetAsync(url);
-            cache.Get(HttpMethod.Get + url).Should().NotBeNull(); // ensure it's cached before the 2nd call
+            cache.Get(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + url).Should().NotBeNull(); // ensure it's cached before the 2nd call
             await client.GetAsync(url);
 
             // validate
@@ -37,14 +37,14 @@ namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
             var cacheTime = TimeSpan.FromSeconds(123);
-            cache.Setup(c => c.CreateEntry(HttpMethod.Get + url));
+            cache.Setup(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + url));
             var client = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
 
             // execute twice, validate cache is called each time
             await client.GetAsync(url);
-            cache.Verify(c => c.CreateEntry(HttpMethod.Get + url), Times.Once);
+            cache.Verify(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + url), Times.Once);
             await client.GetAsync(url);
-            cache.Verify(c => c.CreateEntry(HttpMethod.Get + url), Times.Exactly(2));
+            cache.Verify(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + url), Times.Exactly(2));
         }
 
         [Fact]
@@ -54,15 +54,15 @@ namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IMemoryCache>(MockBehavior.Strict);
             var cacheTime = TimeSpan.FromSeconds(123);
-            cache.Setup(c => c.CreateEntry(HttpMethod.Get + url));
-            cache.Setup(c => c.CreateEntry(HttpMethod.Head + url));
+            cache.Setup(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + url));
+            cache.Setup(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Head + url));
             var client = new HttpClient(new InMemoryCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, null, cache.Object));
 
             // execute twice, validate cache is called each time
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, url));
             await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url));
-            cache.Verify(c => c.CreateEntry(HttpMethod.Head + url), Times.Once);
-            cache.Verify(c => c.CreateEntry(HttpMethod.Get + url), Times.Once);
+            cache.Verify(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Head + url), Times.Once);
+            cache.Verify(c => c.CreateEntry(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + url), Times.Once);
         }
         
         [Fact]
@@ -114,7 +114,7 @@ namespace Cimpress.Extensions.Http.Caching.InMemory.UnitTests
 
             // execute twice
             var result1 = await client1.GetAsync(url);
-            cache.Get(HttpMethod.Get + url).Should().NotBeNull();
+            cache.Get(InMemoryCacheFallbackHandler.CacheFallbackKeyPrefix + HttpMethod.Get + url).Should().NotBeNull();
             var result2 = await client2.GetAsync(url);
 
             // validate

--- a/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheFallbackHandler_when_sending_requests.cs
+++ b/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheFallbackHandler_when_sending_requests.cs
@@ -29,12 +29,12 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.Setup(c => c.SetAsync(method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>())).Returns(Task.FromResult(true));
+            cache.Setup(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>())).Returns(Task.FromResult(true));
             var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
 
             // execute twice
             await client.SendAsync(new HttpRequestMessage(method, url));
-            cache.Verify(c => c.SetAsync(method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once); // ensure it's cached before the 2nd call
+            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once); // ensure it's cached before the 2nd call
             await client.SendAsync(new HttpRequestMessage(method, url));
 
             // validate
@@ -53,9 +53,9 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
 
             // execute twice, validate cache is called each time
             await client.SendAsync(new HttpRequestMessage(method, url));
-            cache.Verify(c => c.SetAsync(method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);
+            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);
             await client.SendAsync(new HttpRequestMessage(method, url));
-            cache.Verify(c => c.SetAsync(method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Exactly(2));
+            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Exactly(2));
         }
 
         [Theory, MemberData(nameof(GetHeadData))]
@@ -100,13 +100,13 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler1 = new TestMessageHandler(content: "message-1", delay: TimeSpan.FromMilliseconds(100));
             var testMessageHandler2 = new TestMessageHandler(content: "message-2");
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.Setup(c => c.SetAsync(method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>())).Returns(Task.FromResult(true));
+            cache.Setup(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>())).Returns(Task.FromResult(true));
             var client1 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler1, TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(1), cache.Object));
             var client2 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler2, TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(1), cache.Object));
 
             // execute twice
             var result1 = await client1.SendAsync(new HttpRequestMessage(method, url));
-            cache.Verify(c => c.SetAsync(method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);
+            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>()), Times.Once);
             var result2 = await client2.SendAsync(new HttpRequestMessage(method, url));
 
             // validate
@@ -132,7 +132,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler1 = new TestMessageHandler(HttpStatusCode.OK, "message-1");
             var testMessageHandler2 = new TestMessageHandler(HttpStatusCode.InternalServerError, "message-2");
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.SetupSequence(c => c.GetAsync(method + url)).ReturnsAsync(default(byte[])).ReturnsAsync(serializedCacheEntry);
+            cache.SetupSequence(c => c.GetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url)).ReturnsAsync(default(byte[])).ReturnsAsync(serializedCacheEntry);
             var client1 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler1, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
             var client2 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler2, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
 


### PR DESCRIPTION
If the CacheHandler and CacheFallbackHandler were used in the same HttpClient, then they used the same keys with different expiration times. That caused a problem with setting the correct expiration time for the key.