### PR TITLE
Handle timeouts to Redis

### DIFF
--- a/src/Cimpress.Extensions.Http.Caching.Redis/DistributedCacheExtensions.cs
+++ b/src/Cimpress.Extensions.Http.Caching.Redis/DistributedCacheExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Cimpress.Extensions.Http.Caching.Abstractions;
 using Microsoft.Extensions.Caching.Distributed;
@@ -15,12 +16,13 @@ namespace Cimpress.Extensions.Http.Caching.Redis
         /// </summary>
         /// <param name="cache">The distributed cache.</param>
         /// <param name="key">The key to retrieve from the cache.</param>
+        /// <param name="cancellationToken">Optional cancellation token to avoid waiting for the cache for too long in case the cache cannot be reached.</param>
         /// <returns>The data of the cache entry, or null if not found or on any error.</returns>
-        public static async Task<CacheData> TryGetAsync(this IDistributedCache cache, string key)
+        public static async Task<CacheData> TryGetAsync(this IDistributedCache cache, string key, CancellationToken cancellationToken = default(CancellationToken))
         {
             try
             {
-                var binaryValue = await cache.GetAsync(key);
+                var binaryValue = await cache.GetAsync(key, cancellationToken);
                 return binaryValue.Deserialize();
             }
             catch (Exception)
@@ -37,14 +39,15 @@ namespace Cimpress.Extensions.Http.Caching.Redis
         /// <param name="key">The key for this cache entry.</param>
         /// <param name="value">The value of this cache entry.</param>
         /// <param name="absoluteExpirationRelativeToNow">Expiration relative to now.</param>
+        /// <param name="cancellationToken">Optional cancellation token to avoid waiting for the cache for too long in case the cache cannot be reached.</param>
         /// <returns>A task, when completed, has tried to put the entry into the cache.</returns>
-        public static async Task TrySetAsync(this IDistributedCache cache, string key, CacheData value, TimeSpan absoluteExpirationRelativeToNow)
+        public static async Task TrySetAsync(this IDistributedCache cache, string key, CacheData value, TimeSpan absoluteExpirationRelativeToNow, CancellationToken cancellationToken = default(CancellationToken))
         {
             try
             {
                 var binaryValue = value.Serialize();
                 var options = new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow };
-                await cache.SetAsync(key, binaryValue, options);
+                await cache.SetAsync(key, binaryValue, options, cancellationToken);
             }
             catch (Exception)
             {

--- a/src/Cimpress.Extensions.Http.Caching.Redis/RedisCacheFallbackHandler.cs
+++ b/src/Cimpress.Extensions.Http.Caching.Redis/RedisCacheFallbackHandler.cs
@@ -64,7 +64,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis
             // start 3 tasks
             var httpSendTask = base.SendAsync(request, cancellationToken);
             var timeoutTask = Task.Delay(maxTimeout, cancellationToken);
-            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var cts = new CancellationTokenSource(maxTimeout);
             var cacheTask = responseCache.TryGetAsync(key, cts.Token);
 
             // ensure the send task completes (or the timeout task, whatever comes first).

--- a/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheFallbackHandler_when_sending_requests.cs
+++ b/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheFallbackHandler_when_sending_requests.cs
@@ -30,12 +30,12 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.Setup(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.FromResult(true));
+            cache.Setup(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
 
             // execute twice
             await client.SendAsync(new HttpRequestMessage(method, url));
-            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Once); // ensure it's cached before the 2nd call
+            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Once); // ensure it's cached before the 2nd call
             await client.SendAsync(new HttpRequestMessage(method, url));
 
             // validate
@@ -49,14 +49,14 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
             var cacheTime = TimeSpan.FromSeconds(123);
-            cache.Setup(c => c.SetAsync(method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.FromResult(true));
+            cache.Setup(c => c.SetAsync(method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, cache.Object));
 
             // execute twice, validate cache is called each time
             await client.SendAsync(new HttpRequestMessage(method, url));
-            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Once);
+            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             await client.SendAsync(new HttpRequestMessage(method, url));
-            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Exactly(2));
+            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [Theory, MemberData(nameof(GetHeadData))]
@@ -66,7 +66,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler = new TestMessageHandler(HttpStatusCode.InternalServerError);
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
             var cacheTime = TimeSpan.FromSeconds(123);
-            cache.Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.FromResult(true));
+            cache.Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             cache.Setup(c => c.GetAsync(method + url, default(CancellationToken))).ReturnsAsync(default(byte[]));
             var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, cache.Object));
 
@@ -74,7 +74,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             await client.SendAsync(new HttpRequestMessage(method, url));
 
             // validate
-            cache.Verify(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Never);
+            cache.Verify(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Theory, MemberData(nameof(GetHeadData))]
@@ -84,7 +84,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler = new TestMessageHandler(HttpStatusCode.InternalServerError);
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
             var cacheTime = TimeSpan.FromSeconds(123);
-            cache.Setup(c => c.GetAsync(method + url, default(CancellationToken))).ReturnsAsync(default(byte[]));
+            cache.Setup(c => c.GetAsync(method + url, It.IsAny<CancellationToken>())).ReturnsAsync(default(byte[]));
             var client = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler, TimeSpan.FromDays(1), cacheTime, cache.Object));
 
             // execute
@@ -101,13 +101,13 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler1 = new TestMessageHandler(content: "message-1", delay: TimeSpan.FromMilliseconds(100));
             var testMessageHandler2 = new TestMessageHandler(content: "message-2");
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.Setup(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.FromResult(true));
+            cache.Setup(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             var client1 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler1, TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(1), cache.Object));
             var client2 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler2, TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(1), cache.Object));
 
             // execute twice
             var result1 = await client1.SendAsync(new HttpRequestMessage(method, url));
-            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Once);
+            cache.Verify(c => c.SetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             var result2 = await client2.SendAsync(new HttpRequestMessage(method, url));
 
             // validate
@@ -133,7 +133,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler1 = new TestMessageHandler(HttpStatusCode.OK, "message-1");
             var testMessageHandler2 = new TestMessageHandler(HttpStatusCode.InternalServerError, "message-2");
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.SetupSequence(c => c.GetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, default(CancellationToken))).ReturnsAsync(default(byte[])).ReturnsAsync(serializedCacheEntry);
+            cache.SetupSequence(c => c.GetAsync(RedisCacheFallbackHandler.CacheFallbackKeyPrefix + method + url, It.IsAny<CancellationToken>())).ReturnsAsync(default(byte[])).ReturnsAsync(serializedCacheEntry);
             var client1 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler1, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
             var client2 = new HttpClient(new RedisCacheFallbackHandler(testMessageHandler2, TimeSpan.FromDays(1), TimeSpan.FromDays(1), cache.Object));
 

--- a/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheHandler_when_cache_unavailable.cs
+++ b/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheHandler_when_cache_unavailable.cs
@@ -20,7 +20,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
             cache.Setup(c => c.GetAsync(HttpMethod.Get + "http://unittest/", default(CancellationToken))).ThrowsAsync(new Exception("unittest"));
-            cache.Setup(c => c.SetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.FromResult(true));
+            cache.Setup(c => c.SetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             var client = new HttpClient(new RedisCacheHandler(testMessageHandler, new Dictionary<HttpStatusCode, TimeSpan>(), cache.Object));
 
             // execute
@@ -29,8 +29,8 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
 
             // validate
             testMessageHandler.NumberOfCalls.Should().Be(1);
-            cache.Verify(c => c.GetAsync(HttpMethod.Get + "http://unittest/", default(CancellationToken)), Times.Once);
-            cache.Verify(c => c.SetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Once);
+            cache.Verify(c => c.GetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<CancellationToken>()), Times.Once);
+            cache.Verify(c => c.SetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
             cache.Setup(c => c.GetAsync(HttpMethod.Get + "http://unittest/", default(CancellationToken))).ReturnsAsync(default(byte[]));
-            cache.Setup(c => c.SetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Throws<Exception>();
+            cache.Setup(c => c.SetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Throws<Exception>();
             var client = new HttpClient(new RedisCacheHandler(testMessageHandler, new Dictionary<HttpStatusCode, TimeSpan>(), cache.Object));
 
             // execute twice
@@ -49,8 +49,8 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
 
             // validate
             testMessageHandler.NumberOfCalls.Should().Be(1);
-            cache.Verify(c => c.GetAsync(HttpMethod.Get + "http://unittest/", default(CancellationToken)), Times.Once);
-            cache.Verify(c => c.SetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Once);
+            cache.Verify(c => c.GetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<CancellationToken>()), Times.Once);
+            cache.Verify(c => c.SetAsync(HttpMethod.Get + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheHandler_when_sending_request.cs
+++ b/test/Cimpress.Extensions.Http.Caching.Redis.UnitTests/RedisCacheHandler_when_sending_request.cs
@@ -30,19 +30,19 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.Setup(c => c.GetAsync(method + "http://unittest/", default(CancellationToken))).ReturnsAsync(default(byte[]));
-            cache.Setup(c => c.SetAsync(method + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.CompletedTask);
+            cache.Setup(c => c.GetAsync(method + "http://unittest/", It.IsAny<CancellationToken>())).ReturnsAsync(default(byte[]));
+            cache.Setup(c => c.SetAsync(method + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
             var client = new HttpClient(new RedisCacheHandler(testMessageHandler, new Dictionary<HttpStatusCode, TimeSpan>(), cache.Object));
 
             // execute twice
             await client.SendAsync(new HttpRequestMessage(method, "http://unittest"));
-            cache.Setup(c => c.GetAsync(method + "http://unittest/", default(CancellationToken))).ReturnsAsync(() => new CacheData(new byte[0], new HttpResponseMessage(HttpStatusCode.OK), null, null).Serialize());
+            cache.Setup(c => c.GetAsync(method + "http://unittest/", It.IsAny<CancellationToken>())).ReturnsAsync(() => new CacheData(new byte[0], new HttpResponseMessage(HttpStatusCode.OK), null, null).Serialize());
             await client.SendAsync(new HttpRequestMessage(method, "http://unittest"));
 
             // validate
             testMessageHandler.NumberOfCalls.Should().Be(1);
-            cache.Verify(c => c.GetAsync(method + "http://unittest/", default(CancellationToken)), Times.Exactly(2));
-            cache.Verify(c => c.SetAsync(method + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Once);
+            cache.Verify(c => c.GetAsync(method + "http://unittest/", It.IsAny<CancellationToken>()), Times.Exactly(2));
+            cache.Verify(c => c.SetAsync(method + "http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Theory, MemberData(nameof(GetHeadData))]
@@ -51,8 +51,8 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.Setup(c => c.GetAsync("http://unittest/", default(CancellationToken))).ReturnsAsync(default(byte[]));
-            cache.Setup(c => c.SetAsync("http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.CompletedTask);
+            cache.Setup(c => c.GetAsync("http://unittest/", It.IsAny<CancellationToken>())).ReturnsAsync(default(byte[]));
+            cache.Setup(c => c.SetAsync("http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
             var client = new HttpClient(new RedisCacheHandler(testMessageHandler, new Dictionary<HttpStatusCode, TimeSpan>(), cache.Object));
 
             // execute twice
@@ -61,7 +61,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             
             // validate
             testMessageHandler.NumberOfCalls.Should().Be(2);
-            cache.Verify(c => c.GetAsync(method + "http://unittest/", default(CancellationToken)), Times.Exactly(2));
+            cache.Verify(c => c.GetAsync(method + "http://unittest/", It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [Theory, MemberData(nameof(GetHeadData))]
@@ -70,8 +70,8 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             // setup
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
-            cache.Setup(c => c.GetAsync(It.IsAny<string>(), default(CancellationToken))).ReturnsAsync(default(byte[]));
-            cache.Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.FromResult(true));
+            cache.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(default(byte[]));
+            cache.Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
             var client = new HttpClient(new RedisCacheHandler(testMessageHandler, new Dictionary<HttpStatusCode, TimeSpan>(), cache.Object));
 
             // execute for different URLs
@@ -80,7 +80,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
 
             // validate
             testMessageHandler.NumberOfCalls.Should().Be(2);
-            cache.Verify(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Exactly(2));
+            cache.Verify(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
         
         [Fact]
@@ -113,8 +113,8 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler = new TestMessageHandler(System.Net.HttpStatusCode.OK, expectedContent, expectedContentTypeHeader, expectedEtag);
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
             byte[] savedData = null;
-            cache.Setup(c => c.GetAsync(It.IsAny<string>(), default(CancellationToken))).ReturnsAsync(savedData);
-            cache.Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Callback((string key, byte[] data, DistributedCacheEntryOptions o, CancellationToken token) => savedData = data)
+            cache.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(savedData);
+            cache.Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Callback((string key, byte[] data, DistributedCacheEntryOptions o, CancellationToken token) => savedData = data)
                 .Returns(Task.FromResult(true));
             var client = new HttpClient(new RedisCacheHandler(testMessageHandler, new Dictionary<HttpStatusCode, TimeSpan>(), cache.Object));
 
@@ -142,8 +142,8 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var testMessageHandler = new TestMessageHandler();
             var cache = new Mock<IDistributedCache>(MockBehavior.Strict);
 
-            cache.Setup(c => c.GetAsync("http://unittest/", default(CancellationToken))).ReturnsAsync(default(byte[]));
-            cache.Setup(c => c.SetAsync("http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.FromResult(true));
+            cache.Setup(c => c.GetAsync("http://unittest/", It.IsAny<CancellationToken>())).ReturnsAsync(default(byte[]));
+            cache.Setup(c => c.SetAsync("http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true));
 
             var cacheExpirationPerStatusCode = new Dictionary<HttpStatusCode, TimeSpan> {{(HttpStatusCode) 200, TimeSpan.FromSeconds(0)}};
 
@@ -156,7 +156,7 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
 
             // validate
             testMessageHandler.NumberOfCalls.Should().Be(2);
-            cache.Verify(c => c.SetAsync("http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken)), Times.Exactly(0));
+            cache.Verify(c => c.SetAsync("http://unittest/", It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()), Times.Exactly(0));
         }
         
         [Fact]
@@ -170,9 +170,9 @@ namespace Cimpress.Extensions.Http.Caching.Redis.UnitTests
             var cacheResult = new CacheData(new byte[0], new HttpResponseMessage(HttpStatusCode.OK), null, null).Serialize();
             var nonCacheResult = default(byte[]);
             var currentResult = nonCacheResult;
-            cache.Setup(c => c.GetAsync(key, default(CancellationToken))).ReturnsAsync(currentResult);
-            cache.Setup(c => c.RemoveAsync(key, default(CancellationToken))).Returns(Task.FromResult(true)).Callback(() => currentResult = nonCacheResult);
-            cache.Setup(c => c.SetAsync(key, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), default(CancellationToken))).Returns(Task.FromResult(true))
+            cache.Setup(c => c.GetAsync(key, It.IsAny<CancellationToken>())).ReturnsAsync(currentResult);
+            cache.Setup(c => c.RemoveAsync(key, It.IsAny<CancellationToken>())).Returns(Task.FromResult(true)).Callback(() => currentResult = nonCacheResult);
+            cache.Setup(c => c.SetAsync(key, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(true))
                 .Callback(() => currentResult = cacheResult);
 
             var cacheExpirationPerStatusCode = new Dictionary<HttpStatusCode, TimeSpan> {{(HttpStatusCode) 200, TimeSpan.FromHours(1)}};


### PR DESCRIPTION
When interacting to Redis, avoid blocking the call for more than 5 seconds.