### PR TITLE
Don't log error on redirect result

### DIFF
--- a/src/Cimpress.Extensions.Http/MessageHandlers/RetryHandler.cs
+++ b/src/Cimpress.Extensions.Http/MessageHandlers/RetryHandler.cs
@@ -51,7 +51,7 @@ namespace Cimpress.Extensions.Http.MessageHandlers
                 {
                     response = await base.SendAsync(request, cancellationToken);
 
-                    if (response.IsSuccessStatusCode)
+                    if ((int) response.StatusCode <= 399)
                     {
                         return response;
                     }


### PR DESCRIPTION
3xx results were treated the same as 4xx results. Don't log this.